### PR TITLE
Spelling bug in development.page

### DIFF
--- a/site/src/development.page
+++ b/site/src/development.page
@@ -52,5 +52,5 @@ link_attrs:
 %ul.benefits
   %li You always know where the project is heading
   %li You see progress on weekly basis
-  %li You can easily change direction where project is going
-  %li You can easing prioritize features and have them delivered fast
+  %li You can easily change the direction where your project is going
+  %li You can easily prioritize features and have them delivered fast


### PR DESCRIPTION
This commit changes two sentences in the development.page in the section: "Why it's good to work with us".
