### PR TITLE
Remove Marcin Grzymski from team

### DIFF
--- a/data/team.json
+++ b/data/team.json
@@ -68,12 +68,6 @@
     "github": "tensaioni"
   },
   {
-    "player": "Marcin Grzymski",
-    "rank": "Developer",
-    "avatar": "marcingrzymski.jpg",
-    "github": "marcinekgd"
-  },
-  {
     "player": "Przemysław Kędzierski",
     "rank": "Developer",
     "avatar": "przemek.jpg",


### PR DESCRIPTION
This PR will remove Marcin Grzymski from team on 'who we are?'